### PR TITLE
[Counsel-Codex] implement newsletter modules

### DIFF
--- a/src/airtable_client.py
+++ b/src/airtable_client.py
@@ -1,9 +1,42 @@
-"""Airtable client wrapper (stub)."""
+"""Airtable client wrapper."""
 
 from __future__ import annotations
 
+import os
+from typing import List
 
-def fetch_records() -> None:
-    """Fetch records from Airtable (placeholder)."""
-    # TODO: implement actual Airtable API calls
-    return None
+import requests  # type: ignore
+from pydantic import BaseModel
+
+
+class Resource(BaseModel):
+    url: str
+    theme: str | None = None
+
+
+class AirtableClient:
+    """Minimal Airtable REST API wrapper."""
+
+    def __init__(self, base_url: str | None = None, api_key: str | None = None) -> None:
+        self.base_url = base_url or os.getenv("AIRTABLE_BASE_URL", "")
+        self.api_key = api_key or os.getenv("AIRTABLE_API_KEY", "")
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+
+    def upsert_resource(self, resource: dict) -> None:
+        """Create or update a resource entry."""
+        url = f"{self.base_url}/resources"
+        requests.post(url, json=resource, headers=self._headers(), timeout=10)
+
+    def get_weekly_resources(self, theme: str) -> List[str]:
+        """Return resource URLs filtered by theme."""
+        url = f"{self.base_url}/resources"
+        resp = requests.get(url, params={"theme": theme, "view": "weekly"}, headers=self._headers(), timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return [item["url"] for item in data.get("records", [])]
+
+
+# Default singleton used by the app
+airtable_client = AirtableClient()

--- a/src/analytics.py
+++ b/src/analytics.py
@@ -1,0 +1,26 @@
+"""Segment analytics wrapper."""
+
+from __future__ import annotations
+
+import os
+
+try:
+    import analytics as segment  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    segment = None
+
+
+WRITE_KEY = os.getenv("SEGMENT_WRITE_KEY", "")
+
+if segment and WRITE_KEY:
+    segment.write_key = WRITE_KEY  # type: ignore[attr-defined]
+
+
+def track_send(campaign_id: str) -> None:
+    """Emit a `CounselCodexSent` event to Segment."""
+
+    if not segment or not WRITE_KEY:
+        return
+    segment.track(  # type: ignore[attr-defined]
+        "newsletter", "CounselCodexSent", {"campaign_id": campaign_id}
+    )

--- a/src/beehiiv.py
+++ b/src/beehiiv.py
@@ -1,0 +1,31 @@
+"""Beehiiv publishing utilities."""
+
+from __future__ import annotations
+
+import os
+import requests  # type: ignore
+
+
+API_URL = "https://api.beehiiv.com/v2/campaigns"
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+def create_campaign(markdown: str, subject: str) -> str:
+    """Publish a campaign and return its ID.
+
+    If ``BEEHIIV_TOKEN`` is not set, the Markdown is returned to stdout and a
+    placeholder ID is returned instead of performing a network request.
+    """
+    token = os.getenv("BEEHIIV_TOKEN")
+    if not token:
+        print(markdown)
+        return "dry-run"
+
+    payload = {"subject": subject, "markdown": markdown}
+    resp = requests.post(API_URL, json=payload, headers=_headers(token), timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    return str(data.get("id", ""))

--- a/src/gpt_clauses.py
+++ b/src/gpt_clauses.py
@@ -1,9 +1,22 @@
-"""Generate contract clause suggestions using OpenAI (stub)."""
+"""Generate contract clause suggestions using OpenAI."""
 
 from __future__ import annotations
 
+from typing import List
 
-def generate_clause(prompt: str) -> str:
-    """Return a clause given a prompt."""
-    # TODO: integrate with OpenAI API
-    return "[Clause draft]"
+import openai  # type: ignore
+
+SYSTEM_PROMPT = "You are an elite legal prompt-engineer specializing in concise, actionable contract language."
+
+
+def make_clauses(resources: List[str]) -> List[str]:
+    """Return a list of clause suggestions based on provided resources."""
+    user_content = "\n".join(resources)
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": f"Generate five bullet clauses using these resources:\n{user_content}"},
+    ]
+    response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+    text = response["choices"][0]["message"]["content"].strip()
+    clauses = [line.lstrip("- ").strip() for line in text.splitlines() if line.strip()]
+    return clauses[:5]

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import argparse
 
+from . import analytics, beehiiv, gpt_clauses, perplexity_scraper, renderer
+from .airtable_client import airtable_client
+
 
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
@@ -11,19 +14,30 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--theme",
         type=str,
-        default="",
+        default="AI and the Law",
         help="Optional theme for the weekly issue.",
     )
     return parser.parse_args()
 
 
+def run_issue(theme: str) -> None:
+    """Generate and publish a single newsletter issue."""
+    links = perplexity_scraper.fetch(theme)
+    for link in links:
+        airtable_client.upsert_resource({"url": link, "theme": theme})
+
+    resources = airtable_client.get_weekly_resources(theme)
+    clauses = gpt_clauses.make_clauses(resources)
+    markdown = renderer.compose_issue(theme, clauses, resources)
+
+    cid = beehiiv.create_campaign(markdown, subject=f"{theme} – Counsel Codex")
+    analytics.track_send(cid)
+
+
 def main() -> None:
     """Entry point for generating a newsletter draft."""
     args = parse_args()
-    # Placeholder for newsletter generation logic
-    print("Generating Counsel Codex newsletter (stub)")
-    if args.theme:
-        print(f"Theme: {args.theme}")
+    run_issue(args.theme)
 
 
 if __name__ == "__main__":

--- a/src/perplexity_scraper.py
+++ b/src/perplexity_scraper.py
@@ -1,9 +1,21 @@
-"""Scraper for AI-law resources from Perplexity (stub)."""
+"""Fetch AI-law links using Perplexity search."""
 
 from __future__ import annotations
 
+import requests  # type: ignore
+from typing import List
 
-def fetch_links() -> list[str]:
-    """Return a list of resource links."""
-    # TODO: implement actual scraping logic
-    return []
+SEARCH_URL = "https://www.perplexity.ai/api/search"
+
+
+def fetch(theme: str) -> List[str]:
+    """Return the top 10 links for the given theme."""
+    resp = requests.get(SEARCH_URL, params={"q": f"{theme} AI law"}, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    links: List[str] = []
+    for item in data.get("web_results", [])[:10]:
+        url = item.get("url") or item.get("sourceUrl")
+        if url:
+            links.append(url)
+    return links

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -1,10 +1,26 @@
-"""Render a Markdown issue from collected content (stub)."""
+"""Render Markdown issues for Counsel Codex."""
 
 from __future__ import annotations
 
+from typing import List
 
-def compose_issue(links: list[str], clause: str) -> str:
-    """Compose a full markdown issue."""
-    # TODO: implement templating logic
-    issue_lines = ["# Counsel Codex", "", *links, "", clause]
-    return "\n".join(issue_lines)
+
+def compose_issue(theme: str, clauses: List[str], resources: List[str]) -> str:
+    """Compose a markdown newsletter using the standard format."""
+    lines = [f"# Counsel Codex – {theme}", ""]
+    lines.append("## Hook")
+    if clauses:
+        lines.append(clauses[0])
+    lines.append("")
+    lines.append("## Value")
+    for clause in clauses[:5]:
+        lines.append(f"- {clause}")
+    lines.append("")
+    lines.append("## Resources")
+    for url in resources:
+        lines.append(f"- {url}")
+    lines.append("")
+    lines.append(
+        "**Ready to streamline your contracts? [Subscribe to Counsel Codex](https://counselcodex.example.com)**"
+    )
+    return "\n".join(lines)

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -1,0 +1,39 @@
+import sys
+import types
+
+
+def test_upsert_and_get(monkeypatch) -> None:
+    sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None, get=lambda *a, **k: None)
+    from src.airtable_client import AirtableClient
+
+
+    posts = []
+    gets = []
+
+    class Response:
+        def __init__(self, json_data):
+            self._json = json_data
+
+        def json(self):
+            return self._json
+
+        def raise_for_status(self):
+            pass
+
+    def fake_post(url, json, headers, timeout):
+        posts.append((url, json))
+        return Response({})
+
+    def fake_get(url, params, headers, timeout):
+        gets.append((url, params))
+        return Response({"records": [{"url": "http://example.com"}]})
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    client = AirtableClient(base_url="http://api")
+    client.upsert_resource({"url": "x"})
+    links = client.get_weekly_resources("theme")
+
+    assert posts
+    assert links == ["http://example.com"]

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,14 @@
+from src import analytics
+
+
+def test_track_send(monkeypatch) -> None:
+    events = []
+
+    class FakeAnalytics:
+        def track(self, user_id, event, properties):
+            events.append((user_id, event, properties))
+
+    monkeypatch.setattr(analytics, "segment", FakeAnalytics())
+    monkeypatch.setattr(analytics, "WRITE_KEY", "key")
+    analytics.track_send("123")
+    assert events == [("newsletter", "CounselCodexSent", {"campaign_id": "123"})]

--- a/tests/test_beehiiv.py
+++ b/tests/test_beehiiv.py
@@ -1,0 +1,13 @@
+import sys
+import types
+
+
+def test_create_campaign_dry_run(capfd, monkeypatch) -> None:
+    sys.modules["requests"] = types.SimpleNamespace(post=lambda *a, **k: None)
+    from src import beehiiv
+
+    monkeypatch.delenv("BEEHIIV_TOKEN", raising=False)
+    cid = beehiiv.create_campaign("markdown", "Subject")
+    assert cid == "dry-run"
+    out, _ = capfd.readouterr()
+    assert "markdown" in out

--- a/tests/test_gpt_clauses.py
+++ b/tests/test_gpt_clauses.py
@@ -1,0 +1,14 @@
+import sys
+import types
+
+
+def test_make_clauses(monkeypatch) -> None:
+    sys.modules['openai'] = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=lambda *a, **k: {
+        "choices": [{"message": {"content": "- a\n- b\n- c\n- d\n- e\n- f"}}]
+    }))
+    from src import gpt_clauses
+
+
+    clauses = gpt_clauses.make_clauses(["x"])
+    assert clauses[:2] == ["a", "b"]
+    assert len(clauses) == 5

--- a/tests/test_perplexity_scraper.py
+++ b/tests/test_perplexity_scraper.py
@@ -1,0 +1,23 @@
+import sys
+import types
+
+
+def test_fetch(monkeypatch) -> None:
+    sys.modules['requests'] = types.SimpleNamespace(get=lambda *a, **k: None)
+    from src import perplexity_scraper
+
+
+    def fake_get(url, params, timeout):
+        class Response:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"web_results": [{"url": f"http://{i}.com"} for i in range(12)]}
+
+        return Response()
+
+    monkeypatch.setattr("requests.get", fake_get)
+    links = perplexity_scraper.fetch("test")
+    assert len(links) == 10
+    assert links[0] == "http://0.com"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -2,8 +2,11 @@ from src.renderer import compose_issue
 
 
 def test_compose_issue() -> None:
-    links = ["http://example.com"]
-    clause = "Example clause"
-    issue = compose_issue(links, clause)
+    theme = "AI Contracts"
+    resources = ["http://example.com"]
+    clauses = ["Clause 1", "Clause 2", "Clause 3", "Clause 4", "Clause 5"]
+    issue = compose_issue(theme, clauses, resources)
     assert "Counsel Codex" in issue
-    assert "Example clause" in issue
+    assert theme in issue
+    assert "Clause 1" in issue
+    assert "http://example.com" in issue


### PR DESCRIPTION
### What & Why
• Added implementations for newsletter modules: Airtable client, Perplexity scraper, GPT clause generator, Beehiiv publisher, Segment analytics wrapper and glue logic in `main.py`.
• Updated renderer to emit Counsel Codex markdown structure and created unit tests for new features.

### Checklist
- [x] Unit tests pass
- [x] ruff / pyright clean
- [ ] Docs updated (if applicable)