### PR TITLE
[Counsel-Codex] use ModuleType for fake modules

### DIFF
--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -1,9 +1,12 @@
 import sys
-import types
+from types import ModuleType
 
 
 def test_upsert_and_get(monkeypatch) -> None:
-    sys.modules['requests'] = types.SimpleNamespace(post=lambda *a, **k: None, get=lambda *a, **k: None)
+    fake_requests = ModuleType("requests")
+    setattr(fake_requests, "post", lambda *a, **k: None)
+    setattr(fake_requests, "get", lambda *a, **k: None)
+    sys.modules["requests"] = fake_requests
     from src.airtable_client import AirtableClient
 
 

--- a/tests/test_beehiiv.py
+++ b/tests/test_beehiiv.py
@@ -1,9 +1,11 @@
 import sys
-import types
+from types import ModuleType
 
 
 def test_create_campaign_dry_run(capfd, monkeypatch) -> None:
-    sys.modules["requests"] = types.SimpleNamespace(post=lambda *a, **k: None)
+    fake_requests = ModuleType("requests")
+    setattr(fake_requests, "post", lambda *a, **k: None)
+    sys.modules["requests"] = fake_requests
     from src import beehiiv
 
     monkeypatch.delenv("BEEHIIV_TOKEN", raising=False)

--- a/tests/test_gpt_clauses.py
+++ b/tests/test_gpt_clauses.py
@@ -1,11 +1,22 @@
 import sys
 import types
+from types import ModuleType
 
 
 def test_make_clauses(monkeypatch) -> None:
-    sys.modules['openai'] = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=lambda *a, **k: {
-        "choices": [{"message": {"content": "- a\n- b\n- c\n- d\n- e\n- f"}}]
-    }))
+    fake_openai = ModuleType("openai")
+    setattr(
+        fake_openai,
+        "ChatCompletion",
+        types.SimpleNamespace(
+            create=lambda *a, **k: {
+                "choices": [
+                    {"message": {"content": "- a\n- b\n- c\n- d\n- e\n- f"}}
+                ]
+            },
+        ),
+    )
+    sys.modules["openai"] = fake_openai
     from src import gpt_clauses
 
 

--- a/tests/test_perplexity_scraper.py
+++ b/tests/test_perplexity_scraper.py
@@ -1,9 +1,11 @@
 import sys
-import types
+from types import ModuleType
 
 
 def test_fetch(monkeypatch) -> None:
-    sys.modules['requests'] = types.SimpleNamespace(get=lambda *a, **k: None)
+    fake_requests = ModuleType("requests")
+    setattr(fake_requests, "get", lambda *a, **k: None)
+    sys.modules["requests"] = fake_requests
     from src import perplexity_scraper
 
 


### PR DESCRIPTION
### What & Why
• Updated several tests to build fake modules with `ModuleType` before importing the code under test.
• Ensures pyright recognizes correct types and reports zero errors.

### Checklist
- [x] Unit tests pass
- [x] ruff / pyright clean
- [ ] Docs updated (if applicable)