### PR TITLE
[Counsel-Codex] unify AIRTABLE env variable

### DIFF
--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -13,7 +13,7 @@ jobs:
       - run: python -m src.main --theme "AI Contract Drafting"
         env:
           OPENAI_API_KEY:   ${{ secrets.OPENAI_API_KEY }}
-          AIRTABLE_KEY:     ${{ secrets.AIRTABLE_KEY }}
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
           PERPLEXITY_KEY:   ${{ secrets.PERPLEXITY_KEY }}
           BEEHIIV_TOKEN:    ${{ secrets.BEEHIIV_TOKEN }}
           SEGMENT_WRITE_KEY:    ${{ secrets.SEGMENT_WRITE_KEY }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ It scrapes fresh AI-law resources, generates ready-to-use contract clauses with 
 |---|---|
 | **Stack** | Python 3.11 • OpenAI • Airtable • Perplexity • Beehiiv |
 | **Automation** | GitHub Actions (cron) |
-| **Dev quick-start** | `pip install -r requirements.txt`<br>`export OPENAI_API_KEY=...`<br>`python -m src.main --theme "AI Contract Drafting"` |
+| **Dev quick-start** | `pip install -r requirements.txt`<br>`export OPENAI_API_KEY=...`<br>`export AIRTABLE_API_KEY=...`<br>`python -m src.main --theme "AI Contract Drafting"` |
 
 For contributor instructions and repo conventions, see **[AGENTS.md](./AGENTS.md)**.


### PR DESCRIPTION
### What & Why
• Aligns environment variable names across workflow and docs.
• `.github/workflows/newsletter.yml` now exports `AIRTABLE_API_KEY`.
• README quick start updated accordingly.

### Checklist
- [ ] Unit tests pass
- [ ] ruff / pyright clean
- [ ] Docs updated