### PR TITLE
[Counsel-Codex] surface Airtable request failures

### DIFF
--- a/src/airtable_client.py
+++ b/src/airtable_client.py
@@ -27,7 +27,8 @@ class AirtableClient:
     def upsert_resource(self, resource: dict) -> None:
         """Create or update a resource entry."""
         url = f"{self.base_url}/resources"
-        requests.post(url, json=resource, headers=self._headers(), timeout=10)
+        resp = requests.post(url, json=resource, headers=self._headers(), timeout=10)
+        resp.raise_for_status()
 
     def get_weekly_resources(self, theme: str) -> List[str]:
         """Return resource URLs filtered by theme."""

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -13,20 +13,24 @@ def test_upsert_and_get(monkeypatch) -> None:
     class Response:
         def __init__(self, json_data):
             self._json = json_data
+            self.called = False
 
         def json(self):
             return self._json
 
         def raise_for_status(self):
-            pass
+            self.called = True
+
+    post_resp = Response({})
+    get_resp = Response({"records": [{"url": "http://example.com"}]})
 
     def fake_post(url, json, headers, timeout):
         posts.append((url, json))
-        return Response({})
+        return post_resp
 
     def fake_get(url, params, headers, timeout):
         gets.append((url, params))
-        return Response({"records": [{"url": "http://example.com"}]})
+        return get_resp
 
     monkeypatch.setattr("requests.post", fake_post)
     monkeypatch.setattr("requests.get", fake_get)
@@ -37,3 +41,5 @@ def test_upsert_and_get(monkeypatch) -> None:
 
     assert posts
     assert links == ["http://example.com"]
+    assert post_resp.called
+    assert get_resp.called


### PR DESCRIPTION
### What & Why
• Upsert operations in `AirtableClient` now capture the post response and call `raise_for_status` to reveal HTTP errors.
• Updated unit test to verify that both upsert and fetch operations invoke `raise_for_status`.

### Checklist
- [ ] Unit tests pass
- [ ] ruff / pyright clean
- [ ] Docs updated (if applicable)