### PR TITLE
[Counsel-Codex] remove stray README separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,3 @@ For contributor instructions and repo conventions, see **[AGENTS.md](./AGENTS.md
 ## License
 
 This project is licensed under the [MIT License](./LICENSE).
-=======


### PR DESCRIPTION
### What & Why
• Deleted an extra separator line from the README.
• The file now ends cleanly with the MIT License notice.

### Checklist
- [x] Unit tests pass
- [x] ruff / pyright clean
- [ ] Docs updated (if applicable)