### PR TITLE
[Counsel-Codex] Add Perplexity auth header

### DIFF
--- a/src/perplexity_scraper.py
+++ b/src/perplexity_scraper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import requests  # type: ignore
 from typing import List
 
@@ -10,7 +11,16 @@ SEARCH_URL = "https://www.perplexity.ai/api/search"
 
 def fetch(theme: str) -> List[str]:
     """Return the top 10 links for the given theme."""
-    resp = requests.get(SEARCH_URL, params={"q": f"{theme} AI law"}, timeout=10)
+    headers = None
+    token = os.getenv("PERPLEXITY_KEY")
+    if token:
+        headers = {"Authorization": f"Bearer {token}"}
+    resp = requests.get(
+        SEARCH_URL,
+        params={"q": f"{theme} AI law"},
+        headers=headers,
+        timeout=10,
+    )
     resp.raise_for_status()
     data = resp.json()
     links: List[str] = []

--- a/tests/test_perplexity_scraper.py
+++ b/tests/test_perplexity_scraper.py
@@ -9,7 +9,7 @@ def test_fetch(monkeypatch) -> None:
     from src import perplexity_scraper
 
 
-    def fake_get(url, params, timeout):
+    def fake_get(url, params, headers=None, timeout=10):
         class Response:
             def raise_for_status(self):
                 pass
@@ -19,7 +19,33 @@ def test_fetch(monkeypatch) -> None:
 
         return Response()
 
-    monkeypatch.setattr("requests.get", fake_get)
+    monkeypatch.setattr(perplexity_scraper.requests, "get", fake_get)
     links = perplexity_scraper.fetch("test")
     assert len(links) == 10
     assert links[0] == "http://0.com"
+
+
+def test_fetch_with_header(monkeypatch) -> None:
+    fake_requests = ModuleType("requests")
+    setattr(fake_requests, "get", lambda *a, **k: None)
+    sys.modules["requests"] = fake_requests
+    from src import perplexity_scraper
+
+    captured_headers = {}
+
+    def fake_get(url, params, headers=None, timeout=10):
+        captured_headers.update(headers or {})
+
+        class Response:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"web_results": []}
+
+        return Response()
+
+    monkeypatch.setattr(perplexity_scraper.requests, "get", fake_get)
+    monkeypatch.setenv("PERPLEXITY_KEY", "tok")
+    perplexity_scraper.fetch("test")
+    assert captured_headers == {"Authorization": "Bearer tok"}


### PR DESCRIPTION
### What & Why
• `src/perplexity_scraper.fetch` now checks `PERPLEXITY_KEY` and sends a bearer token when present.
• Added `test_fetch_with_header` verifying the header.

### Checklist
- [x] Unit tests pass
- [x] ruff / pyright clean
- [ ] Docs updated (if applicable)