### PR TITLE
[Counsel-Codex] log dry run markdown

### DIFF
--- a/src/beehiiv.py
+++ b/src/beehiiv.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import os
+import logging
 import requests  # type: ignore
 
 
 API_URL = "https://api.beehiiv.com/v2/campaigns"
+
+logger = logging.getLogger(__name__)
 
 
 def _headers(token: str) -> dict[str, str]:
@@ -16,12 +19,12 @@ def _headers(token: str) -> dict[str, str]:
 def create_campaign(markdown: str, subject: str) -> str:
     """Publish a campaign and return its ID.
 
-    If ``BEEHIIV_TOKEN`` is not set, the Markdown is returned to stdout and a
-    placeholder ID is returned instead of performing a network request.
+    If ``BEEHIIV_TOKEN`` is not set, the Markdown is logged and a placeholder ID
+    is returned instead of performing a network request.
     """
     token = os.getenv("BEEHIIV_TOKEN")
     if not token:
-        print(markdown)
+        logger.info("Beehiiv dry run markdown:\n%s", markdown)
         return "dry-run"
 
     payload = {"subject": subject, "markdown": markdown}

--- a/tests/test_beehiiv.py
+++ b/tests/test_beehiiv.py
@@ -2,14 +2,21 @@ import sys
 from types import ModuleType
 
 
-def test_create_campaign_dry_run(capfd, monkeypatch) -> None:
+def test_create_campaign_dry_run(monkeypatch) -> None:
     fake_requests = ModuleType("requests")
     setattr(fake_requests, "post", lambda *a, **k: None)
     sys.modules["requests"] = fake_requests
     from src import beehiiv
 
+    logs: list[str] = []
+
+    class FakeLogger:
+        def info(self, msg, *args, **kwargs):
+            logs.append(msg % args if args else msg)
+
+    monkeypatch.setattr(beehiiv, "logger", FakeLogger())
+
     monkeypatch.delenv("BEEHIIV_TOKEN", raising=False)
     cid = beehiiv.create_campaign("markdown", "Subject")
     assert cid == "dry-run"
-    out, _ = capfd.readouterr()
-    assert "markdown" in out
+    assert logs and "markdown" in logs[0]


### PR DESCRIPTION
### What & Why
• `create_campaign` now logs the newsletter Markdown when `BEEHIIV_TOKEN` isn't set, replacing the previous print.
• Added a unit test that patches the logger and verifies logging occurs in dry run mode.

### Checklist
- [x] Unit tests pass
- [x] ruff / pyright clean
- [ ] Docs updated (if applicable)
